### PR TITLE
Add loop within watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Base contents
+- Loop for watcher in case timeouts occur

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ docker-build:
 	cd $(MAKEPATH); docker build -t $(IMAGE) .
 
 install: uninstall
-	helm install -n $(NAMESPACE) --create-namespace image-logger $(MAKEPATH)/chart
+	helm install -n $(NAMESPACE) --create-namespace --wait image-logger $(MAKEPATH)/chart
 
 install-debug: uninstall
-	helm install -n $(NAMESPACE) --create-namespace image-logger $(MAKEPATH)/chart --set logLevel=DEBUG
+	helm install -n $(NAMESPACE) --create-namespace --wait image-logger $(MAKEPATH)/chart --set logLevel=DEBUG
 
 uninstall:
 	-helm uninstall -n $(NAMESPACE) image-logger

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clone the repository, and `cd` into it.
 You can change the namespace name to whatever you prefer.
 
 ```bash
-helm install -n image-logger --create-namespace image-logger ./chart
+helm install -n image-logger --create-namespace --wait image-logger ./chart
 ```
 
 ## Follow Logs


### PR DESCRIPTION
Add loop within watcher in case timeouts occur. This loop uses the same
EventDriver object in order to keep exactly one source of truth for
images on the cluster.