### PR TITLE
Optimize hasher and remove module path from logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Base contents
+- Description and example output to README
 - Loop for watcher in case timeouts occur
+- Security considerations to README
+- Two Docker Hub tags: `unstable` for users and `broken` for development
+
+### Changed
+
+- `env_logger` location from `main.rs` to `lib.rs`
+- Hasher to only be created once during add events
+- Name from "image-logger" to "cluster-image-logger"
+
+### Removed
+
+- Module path from `env_logger` output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,11 +37,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72c1f1154e234325b50864a349b9c8e56939e266a4c307c0f159812df2f9537"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "flate2",
  "futures-core",
  "memchr",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "cc"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,15 +137,29 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time 0.1.43",
  "winapi 0.3.9",
 ]
 
 [[package]]
+name = "cluster-image-logger"
+version = "1.0.0"
+dependencies = [
+ "bimap",
+ "env_logger 0.8.2",
+ "eyre",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "core-foundation"
@@ -178,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys-next"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -234,7 +254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
- "humantime 2.0.1",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -242,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
 dependencies = [
  "indenter",
  "once_cell",
@@ -311,9 +331,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "309f13e3f4be6d5917178c84db67c0b9a09177ac16d4f9a7313a767a68adaa77"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -326,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "7a3b03bd32f6ec7885edeb99acd1e47e20e34fd4dfd3c6deed6fcac8a9d28f6a"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -336,15 +356,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "ed8aeae2b6ab243ebabe6f54cd4cf53054d98883d5d326128af7d57a9ca5cd3d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "3f7836b36b7533d16fd5937311d98ba8965ab81030de8b0024c299dd5d51fb9b"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -353,15 +373,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "d41234e71d5e8ca73d01563974ef6f50e516d71e18f1a2f1184742e31f5d469f"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "3520e0eb4e704e88d771b92d51273ee212997f0d8282f17f5d8ff1cb39104e42"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -371,24 +391,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "c72d188479368953c6c8c7140e40d7a4401674ab3b98a41e60e515d6cbdbe5de"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "08944cea9021170d383287169859c0ca8147d9ec285978393109954448f33cc7"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "d3dd206efbe2ca683b2ce138ccdf61e1b0a63f5816dcedc9d8654c500ba0cea6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -397,7 +417,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -406,13 +426,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -421,7 +441,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -452,11 +472,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -467,7 +487,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -494,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -504,7 +524,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -514,7 +534,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "socket2",
  "tokio",
  "tower-service",
@@ -528,7 +548,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
  "tokio",
@@ -547,24 +567,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "image-logger"
-version = "1.0.0"
-dependencies = [
- "bimap",
- "env_logger 0.8.2",
- "eyre",
- "futures",
- "k8s-openapi",
- "kube",
- "log",
- "tokio",
-]
-
-[[package]]
 name = "indenter"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b772bb6a163b53b7e02b2d4735e0b399df6fc68e74374dbea85cd22a36e9db"
+checksum = "f4d5eb2e114fec2b7fe0fadc22888ad2658789bb7acac4dbee9cf8389f971ec8"
 
 [[package]]
 name = "indexmap"
@@ -626,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcaa8ea719de24e21fe6fddb2ea996ca4e312d467c119f827551c4768d97dc5c"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "serde",
  "serde-value",
@@ -651,7 +657,7 @@ checksum = "7d0ab63beb2437861eba0fcda75b5feb9ef1c0990e63ac22cca0ef9adc4dad74"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "dirs-next",
  "either",
@@ -670,7 +676,7 @@ dependencies = [
  "serde_yaml",
  "static_assertions",
  "thiserror",
- "time 0.2.23",
+ "time 0.2.24",
  "tokio",
  "url",
 ]
@@ -696,21 +702,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -919,11 +925,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -939,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -956,9 +962,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -1016,11 +1022,10 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1029,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1039,33 +1044,36 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
  "redox_syscall",
@@ -1073,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1085,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1106,7 +1114,7 @@ checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1122,7 +1130,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1200,9 +1208,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
 dependencies = [
  "serde_derive",
 ]
@@ -1219,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1254,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
+checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -1362,9 +1370,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "syn"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1373,11 +1381,11 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -1416,29 +1424,28 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "time"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
+checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
 dependencies = [
  "const_fn",
  "libc",
@@ -1493,7 +1500,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -1536,7 +1543,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -1558,7 +1565,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tracing-core",
 ]
 
@@ -1656,15 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1808,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "image-logger"
+name = "cluster-image-logger"
 version = "1.0.0"
 license = "Apache-2.0"
 authors = ["Nick Gerace <nickagerace@gmail.com>"]
 edition = "2018"
 description = "A service that logs container images in your Kubernetes cluster."
 homepage = "https://nickgerace.dev"
-repository = "https://github.com/nickgerace/image-logger/"
+repository = "https://github.com/nickgerace/cluster-image-logger/"
 readme = "README.md"
 keywords = ["kubernetes", "image", "k8s", "logger", "service"]
 categories = ["development-tools", "command-line-interface"]
@@ -16,7 +16,7 @@ bimap = "0.5.3"
 env_logger = "0.8.2"
 eyre = "0.6.3"
 futures = "0.3.8"
-k8s-openapi = { version = "0.10.0", features = ["v1_18"], default-features=false }
+k8s-openapi = { version = "0.10.0", features = ["v1_19"], default-features=false }
 kube = { version = "0.45.0", features = ["derive"] }
 log = "0.4.11"
 tokio = { version = "0.2.24", features = ["macros"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN cargo build --release
 
 FROM scratch
 WORKDIR /bin/
-COPY --from=build /build/target/x86_64-unknown-linux-musl/release/image-logger .
-ENTRYPOINT ["/bin/image-logger"]
+COPY --from=build /build/target/x86_64-unknown-linux-musl/release/cluster-image-logger .
+ENTRYPOINT ["/bin/cluster-image-logger"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 MAKEPATH:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-TAG:=unstable
-IMAGE:=nickgerace/image-logger:$(TAG)
-NAMESPACE:=image-logger
+NAME:=cluster-image-logger
+NAMESPACE:=$(NAME)
+IMAGE_PREFIX:=nickgerace/$(NAME)
+
+BROKEN_TAG:=broken
+BROKEN_IMAGE:=$(IMAGE_PREFIX):$(BROKEN_TAG)
+
+UNSTABLE_TAG:=unstable
+UNSTABLE_IMAGE:=$(IMAGE_PREFIX):$(UNSTABLE_TAG)
 
 run: pre-build
 	cd $(MAKEPATH); cargo run
@@ -25,23 +31,36 @@ unused:
 	cd $(MAKEPATH); cargo +nightly udeps
 
 docker-push: docker-build
-	docker push $(IMAGE)
+	docker push $(UNSTABLE_IMAGE)
 
 docker-test: docker-build
 	@printf "This should fail... We are only trying to see if the binary works at runtime.\n"
-	-docker run $(IMAGE)
+	-docker run $(UNSTABLE_IMAGE)
 
 docker-build:
-	cd $(MAKEPATH); docker build -t $(IMAGE) .
+	cd $(MAKEPATH); docker build -t $(UNSTABLE_IMAGE) .
+
+docker-push-dev: docker-build-dev
+	docker push $(BROKEN_IMAGE)
+
+docker-test-dev: docker-build-dev
+	@printf "This should fail... We are only trying to see if the binary works at runtime.\n"
+	-docker run $(BROKEN_IMAGE)
+
+docker-build-dev:
+	cd $(MAKEPATH); docker build -t $(BROKEN_IMAGE) .
 
 install: uninstall
-	helm install -n $(NAMESPACE) --create-namespace --wait image-logger $(MAKEPATH)/chart
+	helm install -n $(NAMESPACE) --create-namespace --wait $(NAME) $(MAKEPATH)/chart
+
+install-dev: uninstall
+	helm install -n $(NAMESPACE) --create-namespace --wait --set image.tag=broken $(NAME) $(MAKEPATH)/chart
 
 install-debug: uninstall
-	helm install -n $(NAMESPACE) --create-namespace --wait image-logger $(MAKEPATH)/chart --set logLevel=DEBUG
+	helm install -n $(NAMESPACE) --create-namespace --wait $(NAME) $(MAKEPATH)/chart --set logLevel=DEBUG
 
 uninstall:
-	-helm uninstall -n $(NAMESPACE) image-logger
+	-helm uninstall -n $(NAMESPACE) $(NAME)
 	-kubectl delete namespace $(NAMESPACE)
 
 logs:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,43 @@
-# image-logger
+# cluster-image-logger
 
-[![License](https://img.shields.io/github/license/nickgerace/image-logger?style=flat-square)](./LICENSE)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/nickgerace/image-logger/unstable?style=flat-square)](https://hub.docker.com/r/nickgerace/image-logger/tags)
+[![License](https://img.shields.io/github/license/nickgerace/cluster-image-logger?style=flat-square)](./LICENSE)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/nickgerace/cluster-image-logger/unstable?style=flat-square)](https://hub.docker.com/r/nickgerace/cluster-image-logger/tags)
 
 <!--
-[![Latest SemVer GitHub Tag](https://img.shields.io/github/v/tag/nickgerace/image-logger?label=version&style=flat-square)](https://github.com/nickgerace/image-logger/releases/latest)
-[![Crates.io](https://img.shields.io/crates/v/image-logger?style=flat-square)](https://crates.io/crates/image-logger)
-[![Build Status](https://img.shields.io/github/workflow/status/nickgerace/image-logger/merge/main?style=flat-square)](https://github.com/nickgerace/image-logger/actions?query=workflow%3Amerge+branch%3Amain)
+[![Latest SemVer GitHub Tag](https://img.shields.io/github/v/tag/nickgerace/cluster-image-logger?label=version&style=flat-square)](https://github.com/nickgerace/cluster-image-logger/releases/latest)
+[![Crates.io](https://img.shields.io/crates/v/cluster-image-logger?style=flat-square)](https://crates.io/crates/cluster-image-logger)
+[![Build Status](https://img.shields.io/github/workflow/status/nickgerace/cluster-image-logger/merge/main?style=flat-square)](https://github.com/nickgerace/cluster-image-logger/actions?query=workflow%3Amerge+branch%3Amain)
 -->
 
-`image-logger` is a service that logs container images in your Kubernetes cluster.
+`cluster-image-logger` is a service that logs container images in your Kubernetes cluster.
+Specifically, this service logs the "existence" of images based on pod creation and deletion events.
+The "logging" part involves sending a string to STDOUT with the timestamp, log level, and a message indicating what images are new to the cluster, or are no longer being used by any pods in the cluster.
+
+```
+[user at hostname in ~]
+% kubectl logs -n cluster-image-logger $(kubectl get pods -n cluster-image-logger --no-headers -o custom-columns=":metadata.name") --follow
+[2021-01-13T20:50:51Z INFO ] Starting cluster-image-logger... (for more information: https://github.com/nickgerace/cluster-image-logger)
+[2021-01-13T20:50:51Z INFO ] [+|image]  rancher/coredns-coredns:1.8.0  [kube-system|coredns-854c77959c-wtqcc]
+[2021-01-13T20:50:51Z INFO ] [+|image]  rancher/klipper-helm:v0.3.2  [kube-system|helm-install-traefik-p8sg9]
+[2021-01-13T20:50:51Z INFO ] [+|image]  rancher/library-traefik:1.7.19  [kube-system|traefik-6f9cbd9bd4-5c6s6]
+[2021-01-13T20:50:51Z INFO ] [+|image]  rancher/klipper-lb:v0.1.2  [kube-system|svclb-traefik-xn5k5]
+[2021-01-13T20:50:51Z INFO ] [+|image]  rancher/local-path-provisioner:v0.0.14  [kube-system|local-path-provisioner-7c458769fb-wsdz5]
+[2021-01-13T20:50:51Z INFO ] [+|image]  rancher/metrics-server:v0.3.6  [kube-system|metrics-server-86cbb8457f-hdccq]
+[2021-01-13T20:50:51Z INFO ] [+|image]  nickgerace/cluster-image-logger:unstable  [cluster-image-logger|cluster-image-logger-deployment-5ccdc7f99b-rrcqt]
+[2021-01-13T20:51:14Z INFO ] [+|image]  perl  [foo|pi-t5zl5]
+[2021-01-13T20:51:15Z INFO ] [+|image]  nginx:1.14.2  [foo|nginx-deployment-66b6c48dd5-4g5nj]
+[2021-01-13T20:51:35Z INFO ] [-|image]  perl  [foo|pi-t5zl5]
+[2021-01-13T20:51:15Z INFO ] [-|image]  nginx:1.14.2  [foo|nginx-deployment-66b6c48dd5-4g5nj]
+```
+
+How to parse the logs: `[TIMESTAMP LOG_LEVEL ] [ADDED_OR_DELETED_SYMBOL|RESOURCE_TYPE]  IMAGE_NAME:IMAGE_TAG  [POD_NAMESPACE|POD_NAME]`.
 
 ## WARNING: THIS REPOSITORY IS UNSTABLE UNTIL VERSION 1.0.0
 
-Prerequisites to version `1.0.0`...
+Prerequisites to releasing version `1.0.0`...
 
 - [ ] Helm install without cloning repository
-- [ ] GitHub action for binary building
+- [ ] GitHub action for binary stability on `main`
 - [ ] Publish stable Docker images
 - [ ] Add to crates.io
 - [ ] Tag as `1.0.0`
@@ -28,7 +49,7 @@ Clone the repository, and `cd` into it.
 You can change the namespace name to whatever you prefer.
 
 ```bash
-helm install -n image-logger --create-namespace --wait image-logger ./chart
+helm install -n cluster-image-logger --create-namespace --wait cluster-image-logger ./chart
 ```
 
 ## Follow Logs
@@ -36,7 +57,7 @@ helm install -n image-logger --create-namespace --wait image-logger ./chart
 Follow logs via the pod's STDOUT.
 
 ```bash
-kubectl logs -n image-logger $(kubectl get pods -n image-logger --no-headers -o custom-columns=":metadata.name") --follow
+kubectl logs -n cluster-image-logger $(kubectl get pods -n cluster-image-logger --no-headers -o custom-columns=":metadata.name") --follow
 ```
 
 ### Why not use labels to follow logs?
@@ -48,13 +69,19 @@ Using the label selector does not provide an up-to-date stream. Following the lo
 Uninstall the helm chart and delete the namespace to return to where you started.
 
 ```bash
-helm uninstall -n image-logger image-logger
-kubectl delete namespace image-logger
+helm uninstall -n cluster-image-logger cluster-image-logger
+kubectl delete namespace cluster-image-logger
 ```
+
+## Security Implications
+
+The service can `get` and `watch` pods at a `cluster` scope.
+This means that information can be read (not written) from any pod in any namespace.
+Please look at the [chart](./chart) for more information.
 
 ## Changelog
 
-Please check out [CHANGELOG.md](./CHANGELOG.md) for more information.
+Please look at [CHANGELOG.md](./CHANGELOG.md) for more information.
 It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## Code of Conduct

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: image-logger
+name: cluster-image-logger
 description: A service that logs container images in your Kubernetes cluster.
 type: application
 version: 1.0.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
-name: image-logger
+name: cluster-image-logger
 
 image:
-  repository: nickgerace/image-logger
+  repository: nickgerace/cluster-image-logger
   pullPolicy: Always
   tag: unstable
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 /*
- * image-logger
- * https://github.com/nickgerace/image-logger
+ * cluster-image-logger
+ * https://github.com/nickgerace/cluster-image-logger
  * Author: Nick Gerace
  * License: Apache 2.0
  */
@@ -11,15 +11,19 @@ mod watcher;
 
 use eyre::Result;
 use kube::Client;
-use log::debug;
+use log::{debug, info};
 
-/// This function is the primary, backend driver for `image-logger`.
+/// This function is the primary, backend driver for `cluster-image-logger`.
 /// When executed, results will be logged via the [log](https://crates.io/crates/log) crate.
 /// Set the `RUST_LOG` environment variable to change the logging level.
 pub async fn run() -> Result<()> {
+    env_logger::builder().format_module_path(false).init();
+    info!(
+        "Starting cluster-image-logger... (for more information: https://github.com/nickgerace/cluster-image-logger)"
+    );
     debug!("Creating Kubernetes client...");
     let client = Client::try_default().await?;
     watcher::watcher(client.clone()).await?;
-    debug!("Ending watcher...");
+    debug!("Watcher has stopped.");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 /*
- * image-logger
- * https://github.com/nickgerace/image-logger
+ * cluster-image-logger
+ * https://github.com/nickgerace/cluster-image-logger
  * Author: Nick Gerace
  * License: Apache 2.0
  */
@@ -8,17 +8,12 @@
 use std::env;
 
 use eyre::Result;
-use log::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "info");
     }
-    env_logger::init();
-    info!(
-        "Starting image-logger... (for more information: https://github.com/nickgerace/image-logger)"
-    );
-    image_logger::run().await?;
+    cluster_image_logger::run().await?;
     Ok(())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 /*
- * image-logger
- * https://github.com/nickgerace/image-logger
+ * cluster-image-logger
+ * https://github.com/nickgerace/cluster-image-logger
  * Author: Nick Gerace
  * License: Apache 2.0
  */
@@ -30,14 +30,12 @@ pub fn get_images(pod: &Pod) -> Option<Vec<String>> {
     }
 }
 
-pub fn hash_string(s: &str) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    s.hash(&mut hasher);
+pub fn hash_string(s: &str, hasher: &mut DefaultHasher) -> u64 {
+    s.hash(hasher);
     hasher.finish()
 }
 
-pub fn hash_tuple(t: &(&str, &str)) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    t.hash(&mut hasher);
+pub fn hash_tuple(t: &(&str, &str), hasher: &mut DefaultHasher) -> u64 {
+    t.hash(hasher);
     hasher.finish()
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,6 +1,6 @@
 /*
- * image-logger
- * https://github.com/nickgerace/image-logger
+ * cluster-image-logger
+ * https://github.com/nickgerace/cluster-image-logger
  * Author: Nick Gerace
  * License: Apache 2.0
  */


### PR DESCRIPTION
Optimize hasher by only creating it once per add event. Remove module
path from the logger format. Add example output to README. Add
description to README. Rename project to cluster-image-logger from
image-logger.